### PR TITLE
STYLE: Fix `itk-module.cmake` local variable typo.

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -1,7 +1,7 @@
 # the top-level README is used for describing this module, just
 # re-used it for documentation here
-get_filename_component(MY_CURENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-file(READ "${MY_CURENT_DIR}/README.rst" DOCUMENTATION)
+get_filename_component(MY_CURRENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+file(READ "${MY_CURRENT_DIR}/README.rst" DOCUMENTATION)
 
 # itk_module() defines the module dependencies in IOFDF
 # The testing module in IOFDF depends on ITKTestKernel


### PR DESCRIPTION
Fix `itk-module.cmake` local variable typo: change `MY_CURENT_DIR` to
`MY_CURRENT_DIR`.